### PR TITLE
Expose more step control to the solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# This workflow is based on the npm template: https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml
+name: build-and-test
+on:
+  push:
+    branches:
+      - main
+      - master
+      - gha
+  pull_request:
+    branches:
+      - main
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 15.x
+      - run: npm install
+      - run: npm run-script build
+      - run: npm install codecov -g
+      - run: npm run-script test
+      - run: npm run-script lint
+      - uses: codecov/codecov-action@v1
+        with:
+          files: coverage/*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - 10
-before_script:
-  - npm run-script build
-  - npm install codecov -g
-  - npm run-script lint
-after_success:
-  - codecov -f coverage/*.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Dormand–Prince method in javascript
 
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![R build status](https://github.com/mrc-ide/dopri-js/workflows/ci/badge.svg)](https://github.com/mrc-ide/dopri-js/actions)
 [![Build Status](https://travis-ci.org/mrc-ide/dopri-js.svg?branch=master )](https://travis-ci.org/mrc-ide/dopri-js)
 [![codecov.io](https://codecov.io/github/mrc-ide/dopri-js/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/dopri-js?branch=master)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dopri",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Dormand–Prince methods",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/control.ts
+++ b/src/control.ts
@@ -12,7 +12,7 @@ export interface DopriControlParam {
 export function dopriControl(control: Partial<DopriControlParam> = {}) {
     const defaults = {atol: 1e-6, maxSteps: 10000, rtol: 1e-6,
                       stiffCheck: 0, tcrit: Infinity,
-                      stepSizeMin: 0, stepSizeMax: Infinity,
+                      stepSizeMin: 1e-8, stepSizeMax: Infinity,
                       stepSizeMinAllow: false};
     const ret = {
         atol: withDefault(control.atol, defaults.atol),

--- a/src/control.ts
+++ b/src/control.ts
@@ -4,17 +4,26 @@ export interface DopriControlParam {
     rtol: number;
     stiffCheck: number;
     tcrit: number;
+    stepSizeMin: number;
+    stepSizeMax: number;
+    stepSizeMinAllow: boolean;
 }
 
 export function dopriControl(control: Partial<DopriControlParam> = {}) {
     const defaults = {atol: 1e-6, maxSteps: 10000, rtol: 1e-6,
-                      stiffCheck: 0, tcrit: Infinity};
+                      stiffCheck: 0, tcrit: Infinity,
+                      stepSizeMin: 0, stepSizeMax: Infinity,
+                      stepSizeMinAllow: false};
     const ret = {
         atol: withDefault(control.atol, defaults.atol),
         maxSteps: withDefault(control.maxSteps, defaults.maxSteps),
         rtol: withDefault(control.rtol, defaults.rtol),
         stiffCheck: withDefault(control.stiffCheck, defaults.stiffCheck),
         tcrit: withDefault(control.tcrit, defaults.tcrit),
+        stepSizeMin: withDefault(control.stepSizeMin, defaults.stepSizeMin),
+        stepSizeMax: withDefault(control.stepSizeMax, defaults.stepSizeMax),
+        stepSizeMinAllow: withDefault(control.stepSizeMinAllow,
+                                      defaults.stepSizeMinAllow)
     };
 
     if (ret.maxSteps < 1) {

--- a/src/control.ts
+++ b/src/control.ts
@@ -10,20 +10,25 @@ export interface DopriControlParam {
 }
 
 export function dopriControl(control: Partial<DopriControlParam> = {}) {
-    const defaults = {atol: 1e-6, maxSteps: 10000, rtol: 1e-6,
-                      stiffCheck: 0, tcrit: Infinity,
-                      stepSizeMin: 1e-8, stepSizeMax: Infinity,
-                      stepSizeMinAllow: false};
+    const defaults = {atol: 1e-6,
+                      maxSteps: 10000,
+                      rtol: 1e-6,
+                      stepSizeMax: Infinity,
+                      stepSizeMin: 1e-8,
+                      stepSizeMinAllow: false,
+                      stiffCheck: 0,
+                      tcrit: Infinity,
+                     };
     const ret = {
         atol: withDefault(control.atol, defaults.atol),
         maxSteps: withDefault(control.maxSteps, defaults.maxSteps),
         rtol: withDefault(control.rtol, defaults.rtol),
+        stepSizeMax: withDefault(control.stepSizeMax, defaults.stepSizeMax),
+        stepSizeMin: withDefault(control.stepSizeMin, defaults.stepSizeMin),
+        stepSizeMinAllow: withDefault(control.stepSizeMinAllow,
+                                      defaults.stepSizeMinAllow),
         stiffCheck: withDefault(control.stiffCheck, defaults.stiffCheck),
         tcrit: withDefault(control.tcrit, defaults.tcrit),
-        stepSizeMin: withDefault(control.stepSizeMin, defaults.stepSizeMin),
-        stepSizeMax: withDefault(control.stepSizeMax, defaults.stepSizeMax),
-        stepSizeMinAllow: withDefault(control.stepSizeMinAllow,
-                                      defaults.stepSizeMinAllow)
     };
 
     if (ret.maxSteps < 1) {

--- a/src/dopri.ts
+++ b/src/dopri.ts
@@ -55,7 +55,8 @@ export class Dopri implements Integrator {
         this._stepper.reset(t, y);
         this._reset();
         this._h = initialStepSize(this._stepper, t, y,
-                                  this._control.atol, this._control.rtol);
+                                  this._control.atol, this._control.rtol,
+                                  this._control.stepSizeMax);
         this._t = t;
         this._history = [];
         return this;
@@ -185,8 +186,7 @@ export class Dopri implements Integrator {
 }
 
 function initialStepSize(stepper: Stepper, t: number, y: number[],
-                         atol: number, rtol: number) {
-    const stepSizeMax = stepper.stepControl.sizeMax;
+                         atol: number, rtol: number, stepSizeMax: number) {
     // NOTE: This is destructive with respect to most of the information
     // in the object; in particular k2, k3 will be modified.
     const f0 = new Array<number>(stepper.n);

--- a/src/dopri5/control.ts
+++ b/src/dopri5/control.ts
@@ -1,9 +1,6 @@
 import {DopriStepControl} from "../types";
 
 export class Dopri5StepControl implements DopriStepControl {
-    // Essentially unlimited step size
-    public readonly sizeMin = 1e-8; // should be Number.EPSILON, really
-    public readonly sizeMax = Number.MAX_VALUE;
     // For scaling during adaptive stepping
     public readonly factorSafe = 0.9;
     public readonly factorMin = 0.2;  // from dopri5.f:276, retard.f:328

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,6 @@ export type OutputFn = null | ((t: number, y: number[]) => number[]);
 
 export interface DopriStepControl {
     beta: number;
-    sizeMin: number;
-    sizeMax: number;
     factorSafe: number;
     factorMin: number;
     factorMax: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,10 +72,6 @@ export function seqLen(a: number, b: number, len: number): number[] {
     return ret;
 }
 
-export function last<T>(x: T[]): T {
-    return x[x.length - 1];
-}
-
 // See richfitz/ring:inst/include/ring/ring.c - this is closely based
 // off of this; that code was written for the same purpose.
 //

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-
 const SQRT_DBL_EPSILON = Math.pow(2, -52 / 2);
 
 export function square(x: number): number {

--- a/test/test-dopri.js
+++ b/test/test-dopri.js
@@ -69,52 +69,6 @@ describe('integrate logistic', () => {
 });
 
 
-// The issue here is that jsonlite is not saving *all* the precision,
-// in the same way that node is saving.  That makes it impossible to
-// compare as exactly as I can going the other way.
-//
-// actually, things are quite different after 7 steps (the first
-// discrepency creeps in for the first two values.  Then things settle
-// in ok and we get the departure of accuracy at t between 2.25 and
-// 2.5 - after that the differences of 1e-15 or so persist.  The
-// rejected steps are at 0.13 and 6.67 so I don't think that's the
-// problem either.
-describe('integrate lorenz', () => {
-    it ('agrees with reference', () => {
-        var t = utils.seqLen(0, 25, 101);
-        var y0 = [10, 1, 1];
-
-        var sol = dopri.integrate(examples.lorenzRhs(), y0, 0, utils.last(t));
-        var y = sol(t);
-
-        var pathRefJs = "test/ref/lorenz_js.json";
-        var pathRefR = "test/ref/lorenz_r.json";
-
-        if (!fs.existsSync(pathRefJs)) {
-            fs.writeFileSync(pathRefJs, JSON.stringify(y));
-        }
-
-        var cmpJs = JSON.parse(fs.readFileSync(pathRefJs));
-        var cmpR = JSON.parse(fs.readFileSync(pathRefR));
-
-        // This one should just straight up agree:
-        expect(y).to.deep.equal(cmpJs);
-
-        // This one is more complicated:
-        for (var i = 0; i < t.length - 1; ++i) {
-            expect(utils.approxEqualArray(y[i], cmpR[i])).to.eql(true);
-        }
-        // Last one is due to interpolation error - the R version
-        // stops the integrator on the point and the js version allows
-        // us to exceed the point at the moment.
-        expect(utils.approxEqualArray(y[100], cmpR[100], 1e-6)).
-            to.eql(true);
-        expect(utils.approxEqualArray(y[100], cmpR[100], 1e-8)).
-            to.eql(false);
-    });
-});
-
-
 describe('Exceed max steps', () => {
     it('Throws when max steps exceeded', () => {
         var ctl = {maxSteps: 5};

--- a/test/test-dopri.js
+++ b/test/test-dopri.js
@@ -136,9 +136,9 @@ describe('Step size too small', () => {
 
 
 describe('Step size vanished', () => {
-    it('Throws when max steps exceeded', () => {
+    it('Throws when step size vanishes', () => {
         var solver = new dopri.Dopri(examples.exponentialRhs([0.5]), 1);
-        var h = solver._stepper.stepControl.sizeMin;
+        var h = solver._control.stepSizeMin;
 
         solver.initialise(h / 2**(-52), [0.1]);
         solver._h = h;

--- a/test/test-dopri.js
+++ b/test/test-dopri.js
@@ -132,6 +132,21 @@ describe('Step size too small', () => {
         solver.initialise(0, [0.1]);
         expect(() => solver.run(100)).to.throw("step too small");
     });
+
+    // This is easier to verify with Lorenz than flame
+    it('Can continue if told that is ok', () => {
+        var ctl = {stepSizeMin: 0.01, stepSizeMinAllow: true};
+        var solver = new dopri.Dopri(examples.lorenzRhs(), 3, ctl);
+        solver.initialise(0, [10, 1, 1]);
+        solver.run(1);
+
+        var min_diff = Infinity;
+        var history = solver._history;
+        for (var i = 1; i < history.length; ++i) {
+            min_diff = Math.min(min_diff, history[i].t - history[i - 1].t);
+        }
+        expect(min_diff).to.eql(0.01);
+    });
 });
 
 

--- a/test/test-dopri.js
+++ b/test/test-dopri.js
@@ -126,10 +126,10 @@ describe('Exceed max steps', () => {
 
 
 describe('Step size too small', () => {
-    it('Throws when max steps exceeded', () => {
-        var solver = new dopri.Dopri(examples.flameRhs, 1);
+    it('Throws when step size becomes too small', () => {
+        var ctl = {stepSizeMin: 0.1};
+        var solver = new dopri.Dopri(examples.flameRhs, 1, ctl);
         solver.initialise(0, [0.1]);
-        solver._stepper.stepControl.sizeMin = 0.1;
         expect(() => solver.run(100)).to.throw("step too small");
     });
 });


### PR DESCRIPTION
This exposes the full step control interface to the solver, which was apparently only partially done. We now have `stepSizeMin`, `stepSizeMax` and `stepSizeMinAllow`. The latter is the same as https://github.com/mrc-ide/dde/pull/27 and allows flag to be set to allow the integration to continue even though we've hit `stepSizeMin` (but this must be greater than dbl eps).

Fixes #9 