### PR TITLE
Allow vector of critical times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dopri",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Dormand–Prince methods",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/control.ts
+++ b/src/control.ts
@@ -74,6 +74,10 @@ export function dopriControl(control: Partial<DopriControlParam> = {}) {
         tcrit: withDefault(control.tcrit, defaults.tcrit),
     };
 
+    if (ret.tcrit.length > 0) {
+        ret.tcrit = [...ret.tcrit].sort();
+    }
+
     if (ret.maxSteps < 1) {
         throw controlError("maxSteps", "must be at least 1");
     }

--- a/src/control.ts
+++ b/src/control.ts
@@ -24,7 +24,7 @@ export interface DopriControlParam {
      *  in terms of steps
      */
     stiffCheck: number;
-    /** An artray of critical times that the solver must stop at. Use
+    /** An array of critical times that the solver must stop at. Use
      *  this if your system has a singularity that it must not step
      *  past (typically at the end of the simulation), or
      *  discontinuities in any derivatives.
@@ -75,6 +75,7 @@ export function dopriControl(control: Partial<DopriControlParam> = {}) {
     };
 
     if (ret.tcrit.length > 0) {
+        // copy so that we never mutate the argument we were passed
         ret.tcrit = [...ret.tcrit].sort();
     }
 

--- a/src/control.ts
+++ b/src/control.ts
@@ -24,11 +24,12 @@ export interface DopriControlParam {
      *  in terms of steps
      */
     stiffCheck: number;
-    /** A critical time that the solver must stop at. Use this if your
-     *  system has a singularity that it must not step past (typically
-     *  at the end of the simulation).
+    /** An artray of critical times that the solver must stop at. Use
+     *  this if your system has a singularity that it must not step
+     *  past (typically at the end of the simulation), or
+     *  discontinuities in any derivatives.
      */
-    tcrit: number;
+    tcrit: number[];
     /** The minimum allowed step size. If not given then we allow
      *  steps to reduce close to the limit of machine precision. If
      *  the integration attempts to make a step smaller than this, it
@@ -59,7 +60,7 @@ export function dopriControl(control: Partial<DopriControlParam> = {}) {
                       stepSizeMin: 1e-8,
                       stepSizeMinAllow: false,
                       stiffCheck: 0,
-                      tcrit: Infinity,
+                      tcrit: [],
                      };
     const ret = {
         atol: withDefault(control.atol, defaults.atol),

--- a/src/dopri.ts
+++ b/src/dopri.ts
@@ -172,6 +172,9 @@ export class Dopri implements Integrator {
         const facOld = Math.max(this._lastError, 1e-4);
         const stepControl = this._stepper.stepControl;
         const control = this._control;
+        const tcrit = control.tcrit;
+        let tcritIdx = 0;
+        let tcritNext = tcrit.length <= tcritIdx ? Infinity : tcrit[tcritIdx];
 
         while (!success) {
             let forceThisStep = false;
@@ -189,8 +192,12 @@ export class Dopri implements Integrator {
             if (h <= Math.abs(t) * DBL_EPSILON) {
                 throw integrationError("step size vanished", t);
             }
-            if (t + h > control.tcrit) {
-                h = control.tcrit - t;
+            if (t >= tcritNext) {
+                tcritIdx++;
+                tcritNext = tcrit.length <= tcritIdx ? Infinity : tcrit[tcritIdx];
+            }
+            if (t + h > tcritNext) {
+                h = tcritNext - t;
             }
 
             // Carry out the step

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -45,4 +45,11 @@ describe("validate inputs", () => {
         expect(() => {dopriControl({rtol: 0});}).
             toThrow("'rtol' must be strictly positive");
     });
+
+    it("accepts and sorts critical times", () => {
+        expect(dopriControl({tcrit: []}).tcrit).toStrictEqual([]);
+        expect(dopriControl({tcrit: [1]}).tcrit).toStrictEqual([1]);
+        expect(dopriControl({tcrit: [1, 2]}).tcrit).toStrictEqual([1, 2]);
+        expect(dopriControl({tcrit: [2, 1]}).tcrit).toStrictEqual([1, 2]);
+    });
 });

--- a/test/dopri.test.ts
+++ b/test/dopri.test.ts
@@ -267,15 +267,20 @@ describe("tcrit", () => {
         const rhs = function(t: number, y: number[], dydt: number[]) {
             dydt[0] = t >= 5 && t < 6 ? 1 : 0;
         }
-        const solver = new dopri.Dopri(rhs, 1);
-        solver.initialise(0, [5, 6]);
-        solver.run(1);
+        const solver = new dopri.Dopri(rhs, 1, {tcrit: [5, 6]});
+        solver.initialise(0, [1]);
+        let sol = solver.run(10);
 
         const tSol = [0, 1, 5, 5.5, 6, 6.5, 7];
         const ySol = sol(tSol);
 
-        console.log(ySol);
-        //expect(solver["_t"]).toBeGreaterThan(1);
+        const t = solver.steps();
+        expect(t.includes(5)).toBe(true);
+        expect(t.includes(6)).toBe(true);
+        expect(t.includes(4)).toBe(false);
+        expect(t.includes(7)).toBe(false);
 
+        const cmp = [1, 1, 1, 1.5, 2, 2, 2];
+        expect(utils.approxEqualArray(flatten(ySol), cmp, 1e-4)).toBe(true);
     });
 });

--- a/test/dopri.test.ts
+++ b/test/dopri.test.ts
@@ -244,7 +244,7 @@ describe("output", () => {
 });
 
 describe("tcrit", () => {
-    const ctl = {tcrit: 1};
+    const ctl = {tcrit: [1]};
     const rhs = function(t: number, y: number[], dydt: number[]) {
         dydt[0] = 1;
     };
@@ -261,5 +261,21 @@ describe("tcrit", () => {
         solver.initialise(0, [1]);
         solver.run(1);
         expect(solver["_t"]).toBeGreaterThan(1);
+    });
+
+    it("copes with a vector of critical times", () => {
+        const rhs = function(t: number, y: number[], dydt: number[]) {
+            dydt[0] = t >= 5 && t < 6 ? 1 : 0;
+        }
+        const solver = new dopri.Dopri(rhs, 1);
+        solver.initialise(0, [5, 6]);
+        solver.run(1);
+
+        const tSol = [0, 1, 5, 5.5, 6, 6.5, 7];
+        const ySol = sol(tSol);
+
+        console.log(ySol);
+        //expect(solver["_t"]).toBeGreaterThan(1);
+
     });
 });


### PR DESCRIPTION
This PR allows the control parameter to take an array of critical times, with the previous default of `Infinity` logically replaced by `[]`.