### PR TITLE
add publishing pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,6 @@ name: Publish Package to npmjs
 on:
     release:
         types: [published]
-    pull_request:
-        branch: npm-publish-on-release
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# workflow follows example in
+# https://docs.github.com/en/actions/tutorials/publish-packages/publish-nodejs-packages#publishing-packages-to-the-npm-registry
 name: Publish Package to npmjs
 on:
     release:
@@ -17,6 +19,8 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
             - run: npm ci
             - run: npm run build
+              
+              # https://docs.npmjs.com/cli/v11/commands/npm-publish
             - run: npm publish --provenance --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,23 @@
 name: Publish Package to npmjs
 on:
-  release:
-    types: [published]
+    release:
+        types: [published]
+    pull_request:
+        branch: npm-publish-on-release
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v5
+            # Setup .npmrc file to publish to npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20.x"
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm ci
+            - run: npm publish --provenance --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish Package to npmjs
 on:
     release:
         types: [published]
+    pull_request:
+        branch: npm-publish-on-release
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -16,6 +18,7 @@ jobs:
                   node-version: "20.x"
                   registry-url: "https://registry.npmjs.org"
             - run: npm ci
+            - run: npm run build
             - run: npm publish --provenance --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
             - run: npm ci
             - run: npm run build
-              
+
               # https://docs.npmjs.com/cli/v11/commands/npm-publish
             - run: npm publish --provenance --access public
               env:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ A simple adaptive ordinary differential equation (ODE) and delay differential eq
 MIT © Imperial College of Science, Technology and Medicine
 
 Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Publishing to NPM
+
+Automatically publish to [NPM](https://www.npmjs.com). Assuming a version number 1.0.0:
+
+* Create a [release on github](https://github.com/mrc-ide/dopri-js/releases/new)
+* Choose a tag -> Create a new tag: v1.0.0
+* Use this version as the description
+* Optionally describe the release
+* Click "Publish release"
+* This triggers the release workflow and the package will be available on NPM in a few minutes
+
+Note: This package's name on NPM is `@reside-ic/dopri` not `dopri`.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 Automatically publish to [NPM](https://www.npmjs.com). Assuming a version number 1.0.0:
 
-* Create a [release on github](https://github.com/mrc-ide/dopri-js/releases/new)
-* Choose a tag -> Create a new tag: v1.0.0
-* Use this version as the description
-* Optionally describe the release
-* Click "Publish release"
-* This triggers the release workflow and the package will be available on NPM in a few minutes
+- Create a [release on github](https://github.com/mrc-ide/dopri-js/releases/new)
+- Choose a tag -> Create a new tag: v1.0.0
+- Use this version as the description
+- Optionally describe the release
+- Click "Publish release"
+- This triggers the release workflow and the package will be available on NPM in a few minutes
 
 Note: This package's name on NPM is `@reside-ic/dopri` not `dopri`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "dopri",
+    "name": "@reside-ic/dopri",
     "version": "1.0.0",
     "description": "Dormand–Prince methods",
     "main": "dist/dopri.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/dopri",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Dormand–Prince methods",
     "main": "dist/dopri.js",
     "type": "module",


### PR DESCRIPTION
This adds automatic publish to npm on release. I ran a test workflow that triggered on this branch and it published [this](https://www.npmjs.com/package/@reside-ic/dopri?activeTab=readme). The provenance flag is a more secure way of publishing and gives us a nice verification tick on npm

It took 2 tries because i forgot to actually build the package, hence the version bump